### PR TITLE
fixed server.js and made background black

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -13,6 +13,7 @@ body {
     margin: 0;
     height: 100vh;
     width: 100vw;
+    background-color: black;
 }
 
 #vue-app {

--- a/server.js
+++ b/server.js
@@ -11,9 +11,7 @@ Actually... all of this stuff should be served by a real webserver, so uploading
 */
 
 // Basic Middleware
-app.use('/css', express.static(__dirname + '/public/css'));
-app.use('/js', express.static(__dirname + '/public/js'));
-app.use('/views', express.static(__dirname + '/public/views'));
+app.use(express.static(__dirname + '/public'));
 
 // Basic Routes
 app.get('/', (req, res) => {


### PR DESCRIPTION
https://github.com/wetfish/sync/issues/25

this does what it says, and reverts the server.js code to use /public for its directory name as originally intended.