### PR TITLE
updated sync button to add time since last server time stamp.

### DIFF
--- a/public/js/socket-app.js
+++ b/public/js/socket-app.js
@@ -49,8 +49,8 @@ socket.on('timestamp', (data) => {
     vueApp.serverMsg = msg;
     vueApp.latency = latency;
     vueApp.serverTime = data.timestamp;
-    //reset time since last server update variable heartbeat
-    vueApp.heartBeat = 0;
+    //create a new date object for caculating time since last server message
+    vueApp.heartBeat = new Date().getTime();
     //if the latency is over the threshold, then sync it back up
     if(Math.abs(vueApp.latency) >= vueApp.latencyThresholdSeconds) {
         vueApp.timestamp = data.timestamp;

--- a/public/js/vue-app.js
+++ b/public/js/vue-app.js
@@ -82,7 +82,7 @@ const mediaPlayerControls = Vue.component('media-player-controls', {
         },
         resync: function () {
             let mediaPlayer = document.getElementById("media-player");
-            mediaPlayer.currentTime = vueApp.timeSinceLastHeartBeat;   
+            mediaPlayer.currentTime = vueApp.serverTime+vueApp.timeSinceLastHeartBeat;  
         }
     }
 });
@@ -98,6 +98,7 @@ let vueApp = new Vue ({
         timestamp: null,
         duration: null,
         muted: true,
+        heartBeat:null,
         latencyThresholdSeconds: 5
         
     },
@@ -105,18 +106,14 @@ let vueApp = new Vue ({
     },
     computed: { 
         timeSinceLastHeartBeat:function () {
-           return this.serverTime+this.heartBeat;
+            //date objects are in milleseconds, so convert it to seconds.
+            return (new Date().getTime() - vueApp.heartBeat )*.001;
         }
     },
     components: {
         "video-player": videoPlayer,
         "audio-player": audioPlayer
     },
-    mounted() {
-        setInterval(function() {
-            vueApp.heartBeat+=0.2;
-        },200);
-    }
 });
 
 function mountNewPlayer(mediaComponent) {

--- a/public/js/vue-app.js
+++ b/public/js/vue-app.js
@@ -82,7 +82,10 @@ const mediaPlayerControls = Vue.component('media-player-controls', {
         },
         resync: function () {
             let mediaPlayer = document.getElementById("media-player");
-            mediaPlayer.currentTime = vueApp.serverTime+((new Date().getTime() - vueApp.heartBeat )/1000);  
+
+            // get the difference of the last server heart beat in seconds
+            let lastHeartBeatOffset = ((new Date().getTime() - vueApp.heartBeat )/1000);
+            mediaPlayer.currentTime = vueApp.serverTime+lastHeartBeatOffset;  
         }
     }
 });

--- a/public/js/vue-app.js
+++ b/public/js/vue-app.js
@@ -82,7 +82,7 @@ const mediaPlayerControls = Vue.component('media-player-controls', {
         },
         resync: function () {
             let mediaPlayer = document.getElementById("media-player");
-            mediaPlayer.currentTime = vueApp.serverTime+vueApp.timeSinceLastHeartBeat;  
+            mediaPlayer.currentTime = vueApp.serverTime+((new Date().getTime() - vueApp.heartBeat )/1000);  
         }
     }
 });
@@ -100,15 +100,6 @@ let vueApp = new Vue ({
         muted: true,
         heartBeat:null,
         latencyThresholdSeconds: 5
-        
-    },
-    methods: {  
-    },
-    computed: { 
-        timeSinceLastHeartBeat:function () {
-            //date objects are in milleseconds, so convert it to seconds.
-            return (new Date().getTime() - vueApp.heartBeat )*.001;
-        }
     },
     components: {
         "video-player": videoPlayer,


### PR DESCRIPTION
https://github.com/wetfish/sync/issues/48 fixes the issue where the syncing would only occur when a time stamp was issued by a server causing the client to be between 0 to 2.99 seconds, this brings the user within a tenth of a second almost every time if the button isn't clicked repetitively.