### PR TITLE
added iterate 3 times and then quit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 PORT=3000
 URL=http://localhost:3000
+
+##for repeat use true, false, or a number
+REPEAT=false

--- a/media-player.js
+++ b/media-player.js
@@ -6,6 +6,8 @@ let videoTypes = new Set(['.ogv', '.mp4']);
 let audioTypes = new Set(['.mp3', '.flac', '.oga', '.wav']);
 let ambiguousTypes = new Set(['.webm', '.ogg']); // These can be either audio or video
 
+let count = 0;
+
 class MediaPlayer {
 
     constructor(io) {
@@ -14,6 +16,7 @@ class MediaPlayer {
         this.mediaTypes = [];
         this.startTime = null;
         this.filesProcessed = 0;
+        this.playlistCount = 0;
 
         this.playlist = fs.readdirSync('./public/media').filter(this.isValidMediaFile).map(function(file){
             return '/media/'+file;
@@ -102,6 +105,11 @@ class MediaPlayer {
                 duration: duration,
                 mediaType: mediaType
             };
+
+            //on new media event, count each time the index is at zero.
+            if (this.mediaIndex == 0) {
+                this.playlistCount++;
+            }
             this.io.sockets.emit('newMedia', data);
         };
     }

--- a/server.js
+++ b/server.js
@@ -62,18 +62,13 @@ function checkRepeat(repeat, count) {
         console.log('we have played through the list '+count+' times');
         process.exit('bye bye!');
     }
-    else if (repeat==='false') {
+    else if (repeat==='false'&& count == 1) {
         if (count == 1) {
             console.log('we have played through the list');
             process.exit('bye bye!');
         }
-        return;
     }
-    else {
-        //if there's no repeat count or repeat is anything other than false, 
-        //repeat ad infinitum
-        return;
-    }
+//if there's no repeat count or repeat is anything other than false, repeat ad infinitum
 }
 setInterval(() => {
     let index = mediaPlayer.mediaIndex;
@@ -88,6 +83,5 @@ setInterval(() => {
         totalFiles: total
     };
     checkRepeat(repeat,playlistCount);
-    //console.log(index+' --total:'+total);
     io.sockets.emit('timestamp', data);
 }, 3000);

--- a/server.js
+++ b/server.js
@@ -63,10 +63,8 @@ function checkRepeat(repeat, count) {
         process.exit('bye bye!');
     }
     else if (repeat==='false'&& count == 1) {
-        if (count == 1) {
-            console.log('we have played through the list');
-            process.exit('bye bye!');
-        }
+        console.log('we have played through the list');
+        process.exit('bye bye!');
     }
 //if there's no repeat count or repeat is anything other than false, repeat ad infinitum
 }

--- a/server.js
+++ b/server.js
@@ -8,6 +8,8 @@ const MediaPlayer = require('./media-player');
 const app = express();
 const playlistUrl = process.env.URL || 'http://localhost:3000';
 const port = process.env.PORT || 3000;
+const repeat = process.env.REPEAT;
+
 
 /*
 Actually... all of this stuff should be served by a real webserver, so uploading files to clients doesn't block the websocket thread
@@ -53,16 +55,36 @@ io.on('connection', (client) => {
 // Start mediaPlayer
 let mediaPlayer = new MediaPlayer(io);
 mediaPlayer.init();
+
+// Stop server depending on value given from REPEAT constant
+function checkRepeat(repeat, count) {
+    if (repeat==='true'||repeat=='') {
+        return;
+    }
+    if (repeat == count) {
+            console.log('we have played through the list '+count+' times');
+            process.exit('bye bye!');
+        }
+    if (repeat==='false') {
+        if (count == 1) {
+            console.log('we have played through the list');
+            process.exit('bye bye!');
+        }
+        return;
+    }
+}
 setInterval(() => {
     let index = mediaPlayer.mediaIndex;
     let total = mediaPlayer.playlist.length;
     let timestamp = mediaPlayer.getTimestamp();
     let mediaType = mediaPlayer.mediaTypes[index];
+    let playlistCount = mediaPlayer.playlistCount;
     let data = {
         humanReadableIndex: index + 1,
         mediaType: mediaType,
         timestamp: timestamp,
         totalFiles: total
     };
+    checkRepeat(repeat,playlistCount);
     io.sockets.emit('timestamp', data);
 }, 3000);

--- a/server.js
+++ b/server.js
@@ -58,18 +58,20 @@ mediaPlayer.init();
 
 // Stop server depending on value given from REPEAT constant
 function checkRepeat(repeat, count) {
-    if (repeat==='true'||repeat=='') {
-        return;
-    }
     if (repeat == count) {
-            console.log('we have played through the list '+count+' times');
-            process.exit('bye bye!');
-        }
-    if (repeat==='false') {
+        console.log('we have played through the list '+count+' times');
+        process.exit('bye bye!');
+    }
+    else if (repeat==='false') {
         if (count == 1) {
             console.log('we have played through the list');
             process.exit('bye bye!');
         }
+        return;
+    }
+    else {
+        //if there's no repeat count or repeat is anything other than false, 
+        //repeat ad infinitum
         return;
     }
 }
@@ -86,5 +88,6 @@ setInterval(() => {
         totalFiles: total
     };
     checkRepeat(repeat,playlistCount);
+    //console.log(index+' --total:'+total);
     io.sockets.emit('timestamp', data);
 }, 3000);


### PR DESCRIPTION
this fixes https://github.com/wetfish/sync/issues/13 this adds a count variable and optional .env variable to specify whether you want the server to repeat N times or not at all, this would be the first attempt at it, and the behavior is it will stop sending information to the client after it reaches a certain count of going through the list, the client won't see this until they hit the refresh button or notice that that the sync button doesn't work. so it might be a good idea to add something that will stop the client when it reaches the beginning of the set of mediafiles once again.