### PR TITLE
adding m3u support via command args.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Synchronize HTML5 audio and video between friends!
 ### M3U support
 
 -in order to use an m3u file feature simply start sync like this 'npm run start -- --m3u=/path/to/playlist.m3u'
+or node server.js --m3u="path/to/playlist.m3u8"
+
 
 -the m3u file can be located anywhere on the system, however the files it refrences must be in the public directory. otherwise you'll have a black screen, and a file name that says it's playing on the server backend.
 
 -.webm and .ogg are unsupported filetypes if using the m3u option.
+
+

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Synchronize HTML5 audio and video between friends!
 ### M3U support
 
 -in order to use an m3u file feature simply start sync like this 'npm run start -- --m3u=/path/to/playlist.m3u'
-or node server.js --m3u="path/to/playlist.m3u8"
+or node server.js --m3u="path/to/playlist.m3u8" where root is the public folder. 
 
 
 -the m3u file can be located anywhere on the system, however the files it refrences must be in the public directory. otherwise you'll have a black screen, and a file name that says it's playing on the server backend.

--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Synchronize HTML5 audio and video between friends!
 - npm install
 - place mp4,ogv,mp3,flac,oga,wav,webm, or ogg files within /public/media
 - npm start
+
+### M3U support
+
+-in order to use an m3u file feature simply start sync like this 'npm run start -- --m3u=/path/to/playlist.m3u'
+
+-the m3u file can be located anywhere on the system, however the files it refrences must be in the public directory. otherwise you'll have a black screen, and a file name that says it's playing on the server backend.
+
+-.webm and .ogg are unsupported filetypes if using the m3u option.

--- a/media-player.js
+++ b/media-player.js
@@ -160,7 +160,7 @@ class MediaPlayer {
             //if were in m3u mode were passing an object so we have to fetch the url from the object
             if (argv.m3u) {
                 //check the url for a remote http string
-                if (this.playlist[this.mediaIndex]['url'].includes('http')) {
+                if (this.playlist[this.mediaIndex]['url'].startsWith('http')) {
                     url = `${this.playlist[this.mediaIndex]['url']}`;
                 }
                 else {
@@ -239,7 +239,7 @@ class MediaPlayer {
                 //if were in m3u mode were passing an object so we have to fetch the url from the object
                 if (argv.m3u) {
                     //check if the url is remote
-                    if (this.playlist[index]['url'].includes('http')) {
+                    if (this.playlist[index]['url'].startsWith('http')) {
                         console.log(`watching file ${this.playlist[index]['url']}; ${timestamp}s`);
                     }
                     //else include localhost for the person watching the backend of this app.

--- a/media-player.js
+++ b/media-player.js
@@ -189,7 +189,8 @@ class MediaPlayer {
         execute(`${shellCommand} "./public${url}"`, (err, stdout) => {
             let duration = stdout.split('\n')[0]; // Remove \n
             this.mediaLengths[index] = parseFloat(duration);
-            if (++this.filesProcessed === this.mediaLengths.length) {
+            this.filesProcessed++;
+            if (this.filesProcessed === this.mediaLengths.length) {
                 this.setBreakpoints();
                 this.startTimers();
             }
@@ -198,7 +199,8 @@ class MediaPlayer {
     //register media lengths from M3U playlist
     registerMediaLength(file, index) {
         this.mediaLengths[index] = file.duration;
-        if (++this.filesProcessed === this.mediaLengths.length) {
+        this.filesProcessed++;
+        if (this.filesProcessed === this.mediaLengths.length) {
                 this.setBreakpoints();
                 this.startTimers();
             }

--- a/media-player.js
+++ b/media-player.js
@@ -53,7 +53,7 @@ class MediaPlayer {
             //check for a file uri
             if (file.uri) {
                 //get the name of the file which will be the title of the media
-                let name = path.parse(parsedUrl).name;
+                let name = path.parse(file.uri).name;
                 //return an object with relevant information 
                 return {
                     duration:file.duration,

--- a/media-player.js
+++ b/media-player.js
@@ -26,7 +26,6 @@ function importM3U(file) {
 class MediaPlayer {
 
     constructor(io) {
-        // this.playlistType = argv;
         this.io = io;
         this.mediaIndex = 0;
         this.mediaTypes = [];
@@ -53,8 +52,7 @@ class MediaPlayer {
         if (file.duration) {
             //check for a file uri
             if (file.uri) {
-                //remove quotes in filename if they exist.
-                let parsedUrl = path.parse(file.uri).base;
+                //get the name of the file which will be the title of the media
                 let name = path.parse(parsedUrl).name;
                 //return an object with relevant information 
                 return {

--- a/media-player.js
+++ b/media-player.js
@@ -159,7 +159,15 @@ class MediaPlayer {
             let url = `${playlistUrl}${this.playlist[this.mediaIndex]}`;
             //if were in m3u mode were passing an object so we have to fetch the url from the object
             if (argv.m3u) {
-                url = `${playlistUrl}${this.playlist[this.mediaIndex]['url']}`;
+                //check the url for a remote http string
+                if (this.playlist[this.mediaIndex]['url'].includes('http')) {
+                    url = `${this.playlist[this.mediaIndex]['url']}`;
+                }
+                else {
+                    //else its a local file 
+                    url = `${playlistUrl}${this.playlist[this.mediaIndex]['url']}`;
+                }
+                
             }
             const mediaType = this.mediaTypes[this.mediaIndex];
             const duration = this.mediaLengths[this.mediaIndex];

--- a/package-lock.json
+++ b/package-lock.json
@@ -323,6 +323,12 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
     "dotenv": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
@@ -744,6 +750,16 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -945,6 +961,15 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "m3u8-parser": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.4.0.tgz",
+      "integrity": "sha512-iH2AygTFILtato+XAgnoPYzLHM4R3DjATj7Ozbk7EHdB2XoLF2oyOUguM7Kc4UVHbQHHL/QPaw98r7PbWzG0gg==",
+      "dev": true,
+      "requires": {
+        "global": "^4.3.2"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -984,6 +1009,15 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -993,21 +1027,19 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -1146,6 +1178,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "progress": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,6 +202,11 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -297,6 +302,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1651,6 +1661,15 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "mocha || true",
-    "playlist": "node server.js --m3u"
+    "test": "mocha || true"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "mocha || true"
+    "test": "mocha || true",
+    "playlist": "node server.js --m3u"
   },
   "repository": {
     "type": "git",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",
     "bulma": "^0.7.5",
-    "eslint": "^5.12.1"
+    "eslint": "^5.12.1",
+    "m3u8-parser": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "fscreen": "^1.0.2",
     "ip": "^1.1.5",
     "socket.io": "^2.2.0",
-    "vue": "^2.6.4"
+    "vue": "^2.6.4",
+    "yargs-parser": "^18.1.3"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.9.0",

--- a/public/js/socket-app.js
+++ b/public/js/socket-app.js
@@ -26,9 +26,9 @@ socket.on('newMedia', (data) => {
         if (vueApp.mediaElement != data.mediaType + "-player"){
             vueApp.mediaElement = data.mediaType + "-player";
         } else {
-            // If you only change the src attribute, you must load and play 
+            // If you only change the src attribute, you must load the video
+            // vueapp will handle playing of the video
             mediaPlayer.load();
-            mediaPlayer.play();
         }
     } else {
         // Keep track of the media element that should be rendered

--- a/public/js/socket-app.js
+++ b/public/js/socket-app.js
@@ -19,22 +19,23 @@ socket.on('newMedia', (data) => {
     vueApp.url = data.url;
     vueApp.timestamp = 0;
     vueApp.latency = 0;
-    
+    const mediaPlayer = document.getElementById('media-player');
     // Automatically play the next item if the player is not paused
-    if (!document.getElementById('media-player').paused) {
+    if (!mediaPlayer.paused) {
         // Check before updating the type of media player
         if (vueApp.mediaElement != data.mediaType + "-player"){
             vueApp.mediaElement = data.mediaType + "-player";
         } else {
             // If you only change the src attribute, you must load and play 
-            document.getElementById('media-player').load();
-            document.getElementById('media-player').play();
+            mediaPlayer.load();
+            mediaPlayer.play();
         }
     } else {
         // Keep track of the media element that should be rendered
         vueApp.serverMediaType = data.mediaType;
         // And raise a flag
         vueApp.newMediaReceivedDuringPause = true;
+        mediaPlayer.load();
     }
 });
 

--- a/public/js/vue-app.js
+++ b/public/js/vue-app.js
@@ -189,7 +189,7 @@ function mountNewPlayer(mediaComponent) {
         if (vueApp.newMediaReceivedDuringPause) {
             mediaPlayer.load();
             mediaPlayer.currentTime = vueApp.timestamp;
-            mediaPlayer.play();
+            mediaElement.pause();
             vueApp.newMediaReceivedDuringPause = false;
         } else if (vueApp.latency > vueApp.latencyThresholdSeconds) {
             // In order to catch latency issues, make sure that the latency

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const app = express();
 const playlistUrl = process.env.URL || 'http://localhost:3000';
 const port = process.env.PORT || 3000;
 const repeat = process.env.REPEAT;
-
+const argv = require('yargs-parser')(process.argv);
 
 /*
 Actually... all of this stuff should be served by a real webserver, so uploading files to clients doesn't block the websocket thread
@@ -40,6 +40,11 @@ let io = socket(server);
 io.on('connection', (client) => {
     let index = mediaPlayer.mediaIndex;
     let url = `${playlistUrl}${mediaPlayer.playlist[index]}`;
+    if (argv.hasOwnProperty('m3u')) {
+        //console.log(`${playlistUrl}${mediaPlayer.playlist[index]}`);
+        url = `${playlistUrl}${mediaPlayer.playlist[index]['url']}`;
+    }
+    else url = `${playlistUrl}${mediaPlayer.playlist[index]}`;
     let timestamp = mediaPlayer.getTimestamp();
     let mediaType = mediaPlayer.mediaTypes[index];
     let duration = mediaPlayer.mediaLengths[index];

--- a/server.js
+++ b/server.js
@@ -40,9 +40,14 @@ let io = socket(server);
 io.on('connection', (client) => {
     let index = mediaPlayer.mediaIndex;
     let url = `${playlistUrl}${mediaPlayer.playlist[index]}`;
-    if (argv.hasOwnProperty('m3u')) {
-        //console.log(`${playlistUrl}${mediaPlayer.playlist[index]}`);
-        url = `${playlistUrl}${mediaPlayer.playlist[index]['url']}`;
+    if (argv.m3u) {
+        //if the url is remote, don't append the project root url
+        if (url.includes('http')) {
+            url = `${mediaPlayer.playlist[index]['url']}`;
+        }
+        else {
+            url = `${playlistUrl}${mediaPlayer.playlist[index]['url']}`;
+        }
     }
     else url = `${playlistUrl}${mediaPlayer.playlist[index]}`;
     let timestamp = mediaPlayer.getTimestamp();

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ io.on('connection', (client) => {
     let url = `${playlistUrl}${mediaPlayer.playlist[index]}`;
     if (argv.m3u) {
         //if the url is remote, don't append the project root url
-        if (url.includes('http')) {
+        if (url.startsWith('http')) {
             url = `${mediaPlayer.playlist[index]['url']}`;
         }
         else {


### PR DESCRIPTION
https://github.com/wetfish/sync/issues/24  this is a better implementation of m3u support from a maintainment perspective, a user will pass in the argument --m3u when running node server.js. a command called playlist is there for conveniance. so the code can be run in m3u playlist mode. so far it converts the file to json as a list of objects containing, name duration, and filename. still need to implement extention checking which could be done in the contructor, but i think it would be better to use the existing architecture on this one.

here is an example playlist
[test_playlist.m3u.zip](https://github.com/wetfish/sync/files/5250383/test_playlist.m3u.zip)
