### PR TITLE
added persist volume and fixed initial volume setting.

### DIFF
--- a/public/js/vue-app.js
+++ b/public/js/vue-app.js
@@ -98,6 +98,8 @@ const mediaPlayerControls = Vue.component('media-player-controls', {
                 startbutton.classList.remove("is-active");
                 mediaPlayer.play();
                 mediaPlayer.muted = false;
+                //set the volume when the user actually hits play
+                mediaPlayer.volume = this.volume*.01;
             }
             else if(!mediaPlayer.paused) {
                 playbutton.setAttribute('xlink:href','regular.svg#play-circle');
@@ -117,6 +119,8 @@ const mediaPlayerControls = Vue.component('media-player-controls', {
             // get the media player element and set it's volume to whatever the slider value is
             let mediaPlayer = document.querySelector("#media-player");
             mediaPlayer.volume = this.volume*.01;
+            //save the volum in local storage
+            localStorage.setItem('volume',this.volume);
         },
         mute: function () {
             //get the media element and make mute/unmute toggle
@@ -135,10 +139,12 @@ const mediaPlayerControls = Vue.component('media-player-controls', {
     },
     mounted() {
         //get the mediaPlayer element set up default volume
-        let mediaPlayer = document.querySelector("#media-player");
-        this.volume = this.$attrs.appvolume;
-        this.muted = false;
-        mediaPlayer.volume = this.volume*.01;
+        if (localStorage.getItem('volume')) {
+            this.volume = localStorage.getItem('volume');
+        }
+        else {
+            this.volume = this.$attrs.appvolume;
+        }
     }
 });
 


### PR DESCRIPTION
https://github.com/wetfish/sync/issues/58 this fixes initial volume setting as well as saves the last set volume into localstorage. now volume is set when the user hits play rather then on mounted which produces an error on page load.